### PR TITLE
Make pylint and robotpy test pass.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 [tool.robotpy]
 
 # Version of robotpy this project depends on
-robotpy_version = "2025.1.1.1"
+robotpy_version = "2025.2.1.0"
 
 # Which extra RobotPy components should be installed
 # -> equivalent to `pip install robotpy[extra1, ...]

--- a/utils/signalLogging.py
+++ b/utils/signalLogging.py
@@ -50,27 +50,27 @@ class SignalWrangler(metaclass=Singleton):
 
     def newLogVal(self, name:str, valGetter:Callable[[],float], units:str|None):
 
-            # Set up NT publishing
-            sigTopic = self.table.getDoubleTopic(name)
-            sigPub = sigTopic.publish(
-                nt.PubSubOptions(sendAll=True, keepDuplicates=True)
+        # Set up NT publishing
+        sigTopic = self.table.getDoubleTopic(name)
+        sigPub = sigTopic.publish(
+            nt.PubSubOptions(sendAll=True, keepDuplicates=True)
+        )
+        sigPub.setDefault(0)
+
+        if(units is not None):
+            sigTopic.setProperty("units", str(units))
+
+        # Set up log file publishing if enabled
+        if self.log is not None:
+            sigLog = wpilog.DoubleLogEntry(
+                log=self.log, name=sigNameToNT4TopicName(name)
             )
-            sigPub.setDefault(0)
+        else:
+            sigLog = None
 
-            if(units is not None):
-                sigTopic.setProperty("units", str(units))
-
-            # Set up log file publishing if enabled
-            if self.log is not None:
-                sigLog = wpilog.DoubleLogEntry(
-                    log=self.log, name=sigNameToNT4TopicName(name)
-                )
-            else:
-                sigLog = None
-
-            self.loggedValList.append(
-                _LoggedVal(valGetter,sigPub, sigLog)
-            )
+        self.loggedValList.append(
+            _LoggedVal(valGetter,sigPub, sigLog)
+        )
 
 
 
@@ -79,26 +79,25 @@ class SignalWrangler(metaclass=Singleton):
 # Public API
 ###########################################
 
-_singletonInst = SignalWrangler() # cache a reference
 def logUpdate():
     """
     Periodic call to sample and broadcast all logged values. Should happen once per 
     20ms loop.
     """
-    _singletonInst.update()
+    SignalWrangler().update()
 
-def addLog(alias: str, value_getter: Callable[[], float], units=None) -> None:
+def addLog(alias: str, valueGetter: Callable[[], float], units=None) -> None:
     """
-    Register some value to be loggd
+    Register some value to be logged
 
     Parameters:
     - alias: The name used to identify the log.
-    - value_getter: A function that returns the current value of the log. Lambda is acceptable here.
+    - valueGetter: A function that returns the current value of the log. Lambda is acceptable here.
     """
-    _singletonInst.newLogVal(alias, value_getter, units)
+    SignalWrangler().newLogVal(alias, valueGetter, units)
 
-def log(alias: str, value_getter, units=None) -> None:
-    addLog(alias, value_getter, units)
+def log(alias: str, valueGetter, units=None) -> None:
+    addLog(alias, valueGetter, units)
 
 def sigNameToNT4TopicName(name):
     return f"/{BASE_TABLE}/{name}"


### PR DESCRIPTION
This pull request makes 

` robotpy test pyfrc_test.py -- --no-header -vvv -s`

and

`pylint --rcfile=.pylintrc --source-roots=. utils\signalLogging.py`

pass.

This line:

https://github.com/RobotCasserole1736/RobotCasserole2025/blob/902ba40f83ad67a8f2dd23db6c10b35afdf920c9/utils/signalLogging.py#L82

was causing any import of `signalLogging.py` to keep a reference to the SignalWrangler singleton which was keeping references to other Singletons in  SignalWrangler().loggedValList[n].valGetter leading to references to SparkMax objects to be kept here:

https://github.com/RobotCasserole1736/RobotCasserole2025/blob/902ba40f83ad67a8f2dd23db6c10b35afdf920c9/wrappers/wrapperedSparkMax.py#L18

keeping `canID` references across simulated game restarts in `tests\pyfrc_test.py`.

Ideally `robotpy` and`WPILib` would invalid the `SparkMax` objects and their `canID` references across simulated game restarts or power-up, but they don't. 

So as a work around we need to not keep any references to those objects in a module or Singleton passed a simulated robot shutdown in pyfrc_test.py.

An alternate approach that should also work would be to empty SignalWrangler().loggedValList on a shutdown. But, it wouldn't be as realistic because the SignalWrangler() object would retain state across simulated power-ups.

FYI @gerth2.