### PR TITLE
Add support for rev maxSwerve modules.

### DIFF
--- a/drivetrain/drivetrainControl.py
+++ b/drivetrain/drivetrainControl.py
@@ -1,6 +1,6 @@
 from wpimath.kinematics import ChassisSpeeds
 from wpimath.geometry import Pose2d, Rotation2d
-from Autonomous.commands.driveForwardSlowCommand import DriveForwardSlowCommand
+#from Autonomous.commands.driveForwardSlowCommand import DriveForwardSlowCommand
 from drivetrain.poseEstimation.drivetrainPoseEstimator import DrivetrainPoseEstimator
 from drivetrain.swerveModuleControl import SwerveModuleControl
 from drivetrain.swerveModuleGainSet import SwerveModuleGainSet
@@ -10,6 +10,12 @@ from drivetrain.drivetrainPhysical import (
     FR_ENCODER_MOUNT_OFFSET_RAD,
     BL_ENCODER_MOUNT_OFFSET_RAD,
     BR_ENCODER_MOUNT_OFFSET_RAD,
+    FL_INVERT_WHEEL_MOTOR,
+    FR_INVERT_WHEEL_MOTOR,
+    BL_INVERT_WHEEL_MOTOR,
+    BR_INVERT_WHEEL_MOTOR,
+    INVERT_AZMTH_MOTOR,
+    INVERT_AZMTH_ENCODER,
     kinematics,
 )
 from drivetrain.drivetrainCommand import DrivetrainCommand
@@ -39,19 +45,23 @@ class DrivetrainControl(metaclass=Singleton):
         self.modules = []
         self.modules.append(
             SwerveModuleControl("FL", DT_FL_WHEEL_CANID, DT_FL_AZMTH_CANID, DT_FL_AZMTH_ENC_PORT, 
-                                FL_ENCODER_MOUNT_OFFSET_RAD, True, True)
+                                FL_ENCODER_MOUNT_OFFSET_RAD,
+                                FL_INVERT_WHEEL_MOTOR, INVERT_AZMTH_MOTOR, INVERT_AZMTH_ENCODER)
         )
         self.modules.append(
             SwerveModuleControl("FR", DT_FR_WHEEL_CANID, DT_FR_AZMTH_CANID, DT_FR_AZMTH_ENC_PORT, 
-                                FR_ENCODER_MOUNT_OFFSET_RAD, True, True)
+                                FR_ENCODER_MOUNT_OFFSET_RAD,
+                                FR_INVERT_WHEEL_MOTOR, INVERT_AZMTH_MOTOR, INVERT_AZMTH_ENCODER)
         )
         self.modules.append(
             SwerveModuleControl("BL", DT_BL_WHEEL_CANID, DT_BL_AZMTH_CANID, DT_BL_AZMTH_ENC_PORT, 
-                                BL_ENCODER_MOUNT_OFFSET_RAD, False, True)
+                                BL_ENCODER_MOUNT_OFFSET_RAD,
+                                BL_INVERT_WHEEL_MOTOR, INVERT_AZMTH_MOTOR, INVERT_AZMTH_ENCODER)
         )
         self.modules.append(
             SwerveModuleControl("BR", DT_BR_WHEEL_CANID, DT_BR_AZMTH_CANID, DT_BR_AZMTH_ENC_PORT, 
-                                BR_ENCODER_MOUNT_OFFSET_RAD, False, True)
+                                BR_ENCODER_MOUNT_OFFSET_RAD,
+                                BR_INVERT_WHEEL_MOTOR, INVERT_AZMTH_MOTOR, INVERT_AZMTH_ENCODER)
         )
 
         self.desChSpd = ChassisSpeeds()

--- a/drivetrain/drivetrainPhysical.py
+++ b/drivetrain/drivetrainPhysical.py
@@ -7,6 +7,7 @@ from utils.units import lbsToKg
 from utils.units import deg2Rad
 from utils.units import in2m
 from utils.robotIdentification import RobotIdentification, RobotTypes
+from wrappers.wrapperedSRXMagEncoder import WrapperedSRXMagEncoder
 
 """
 Defines the physical dimensions and characteristics of the drivetrain
@@ -104,6 +105,16 @@ MAX_ROTATE_ACCEL_RAD_PER_SEC_2 = (
 # 5 - Redeploy code, verify that the  encoder readings are correct as each module is manually rotated
 
 
+# Perhaps we invert the swerve module azimuth motor
+INVERT_AZMTH_MOTOR = True
+INVERT_AZMTH_ENCODER = False
+
+# Perhaps we invert the swerve module wheel motor drive direction
+FL_INVERT_WHEEL_MOTOR = True
+FR_INVERT_WHEEL_MOTOR = True
+BL_INVERT_WHEEL_MOTOR = False
+BR_INVERT_WHEEL_MOTOR = False
+
 if RobotIdentification().getRobotType() == RobotTypes.Main:
     FR_ENCODER_MOUNT_OFFSET_RAD = 0.8412
     FL_ENCODER_MOUNT_OFFSET_RAD = 0.2412
@@ -120,6 +131,15 @@ FL = 0
 FR = 1
 BL = 2
 BR = 3
+
+# Function make a swerve module azimuth encoder reader object
+def wrapperedSwerveDriveAzmthEncoder(azmthEncoderPortIdx, moduleName, azmthOffsetRad, inverted):
+    return WrapperedSRXMagEncoder(
+        port=azmthEncoderPortIdx,
+        name=moduleName,
+        mountOffsetRad=azmthOffsetRad,
+        dirInverted=inverted
+    )
 
 # Camera Mount Offsets
 # These are relative to the robot origin

--- a/wrappers/wrapperedPulseWidthEncoder.py
+++ b/wrappers/wrapperedPulseWidthEncoder.py
@@ -1,7 +1,7 @@
 import math
 from wpilib import DigitalInput, DutyCycle
 from utils.faults import Fault
-from utils.signalLogging import addLog
+#from utils.signalLogging import addLog
 from utils.calibration import Calibration
 from utils.units import wrapAngleRad
 
@@ -20,9 +20,9 @@ class WrapperedPulseWidthEncoder:
         name,
         mountOffsetRad,
         dirInverted,
-        minPulse,
-        maxPulse,
-        minAcceptableFreq,
+        minPulseSec,
+        maxPulseSec,
+        minAcceptableFreqHz,
     ):
         self.dutyCycle = DutyCycle(DigitalInput(port))
         self.name = f"Encoder_{name}"
@@ -34,9 +34,9 @@ class WrapperedPulseWidthEncoder:
         self.curAngleRad = 0
         self.dirInverted = dirInverted
 
-        self.minPulseTimeSec = minPulse
-        self.maxPulseTimeSec = maxPulse
-        self.minAcceptableFreq = minAcceptableFreq
+        self.minPulseTimeSec = minPulseSec
+        self.maxPulseTimeSec = maxPulseSec
+        self.minAcceptableFreqHz = minAcceptableFreqHz
 
         self.freq = 0
         self.pulseTime = 0
@@ -49,7 +49,7 @@ class WrapperedPulseWidthEncoder:
         """Return the raw angle reading from the sensor in radians"""
         self.freq = self.dutyCycle.getFrequency()
         self.faulted = (
-            self.freq < self.minAcceptableFreq
+            self.freq < self.minAcceptableFreqHz
         )  # abnormal frequency, we must be faulted
         self.disconFault.set(self.faulted)
 

--- a/wrappers/wrapperedRevThroughBoreEncoder.py
+++ b/wrappers/wrapperedRevThroughBoreEncoder.py
@@ -1,0 +1,21 @@
+
+from wrappers.wrapperedPulseWidthEncoder import WrapperedPulseWidthEncoder
+
+""" 
+Wrappers a CTRE SRX Magnetic absolute encoder
+https://store.ctr-electronics.com/srx-mag-encoder/
+Assumes the absolute-angle signal from the encoder has 
+been connected to a DIO port on the RoboRIO.
+"""
+
+
+class WrapperedRevThroughBoreEncoder(WrapperedPulseWidthEncoder):
+    def __init__(self, port, name, mountOffsetRad, dirInverted):
+        WrapperedPulseWidthEncoder.__init__(self,
+            port=port,
+            name=name,
+            mountOffsetRad=mountOffsetRad,
+            dirInverted=dirInverted,
+            minPulseSec=1e-6,
+            maxPulseSec=1025e-6,
+            minAcceptableFreqHz=0.9 / 1025e-6)

--- a/wrappers/wrapperedSparkMax.py
+++ b/wrappers/wrapperedSparkMax.py
@@ -1,9 +1,10 @@
-from rev import SparkMax, SparkBase, SparkMaxConfig, REVLibError, ClosedLoopSlot, SparkBaseConfig, ClosedLoopConfig, SparkClosedLoopController
+import time
+from rev import SparkMax, SparkBase, SparkMaxConfig, REVLibError, ClosedLoopSlot, SparkBaseConfig
+from rev import SparkClosedLoopController
 from wpilib import TimedRobot
 from utils.signalLogging import addLog
 from utils.units import rev2Rad, rad2Rev, radPerSec2RPM, RPM2RadPerSec
 from utils.faults import Fault
-import time
 
 
 ## Wrappered Spark Max
@@ -23,6 +24,7 @@ class WrapperedSparkMax:
         self.disconFault = Fault(f"Spark Max {name} ID {canID} disconnected")
         self.simActPos = 0
 
+        # pylint: disable= R0801
         self.desPos = 0
         self.desVel = 0
         self.desVolt = 0


### PR DESCRIPTION
Add support for Rev MaxSwerve Modules.

Differences caused by the MaxSwerve modules include:

- Rev Through Bore Encoder for azimuth angle sensors
- The build instructions mount the Rev Though Bore encoders upside down compared to existing swerve modules
- The azimuth motor drive direction is inverted versus existing swerve modules
- There is a difference in preference or build between Spires and RobotCasserole on inverting the the drive motors.

-Mike

@gerth2 